### PR TITLE
Fix SPM build warning "unhandled" file.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,8 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "JsonAPI",
-            dependencies: []),
+            dependencies: [],
+            exclude: ["Sources/JsonAPI/Info.plist"]),
         .testTarget(
             name: "JsonAPITests",
             dependencies: ["JsonAPI"]),


### PR DESCRIPTION
Solves the building warning: #4
found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target